### PR TITLE
Hh/dtm 421/yml with variables

### DIFF
--- a/lib/hodor/environment.rb
+++ b/lib/hodor/environment.rb
@@ -103,13 +103,8 @@ module Hodor
 
       @target_cluster[:target] = target_env
 
-      @egress_targets = yml_load('config/egress.yml')
-      @egress_to = @egress_targets[@target_cluster[:egress_to].to_sym]
-
       @loaded = true
-
       yml_expand(@target_cluster, [@clusters])
-      yml_expand(@egress_to, [@egress_targets])
     end
 
     def prefs
@@ -205,12 +200,6 @@ module Hodor
       @target_cluster
     end
 
-    def egress_to
-      load_settings if !@loaded || !@target_cluster || !@egress_to
-      raise "No settings for target cluster '#{hadoop_env}' were loaded" if !@loaded || !@target_cluster
-      @egress_to
-    end
-
     def [](key)
       target_cluster[key]
     end
@@ -293,11 +282,6 @@ module Hodor
         flat_vals = ["#{parent_key} = #{val}"]
       end
       flat_vals
-    end
-
-    def render_egress_config
-      flat_vals = yml_flatten('', egress_to)
-      flat_vals.join("\n")
     end
 
     # Run an ssh command, performing any optional variable expansion

--- a/lib/hodor/environment.rb
+++ b/lib/hodor/environment.rb
@@ -262,10 +262,10 @@ module Hodor
         }
       elsif val.is_a? Hash
         more_parents = parents << val
-        val.each_pair { |k, v|
+        val.each_pair do |k, v|
           exp_val = yml_expand(v, more_parents)
           val[k] = exp_val
-        }
+        end
       else
         val
       end

--- a/spec/unit/hodor/environment_spec.rb
+++ b/spec/unit/hodor/environment_spec.rb
@@ -58,22 +58,18 @@ module Hodor
     end
     context 'transforming yaml' do
       subject(:environment) { Hodor::Environment.instance }
-      let(:part_to_process) { "partc://${^part_one}:${^part_two}/${part_a}/${^part_two}/${^down_one}" }
-      let(:processed_yml) { 'partc://part_one:part_two/part_ay/part_two/d1' }
-      let(:yml_read) { {:tspec => "tttt",
-                        :rspec => { :item_one => { :part_one => "part_1",
-                                                 :part_two => "${^part_one}+2",
-                                                 :embedded => { :down_one => "d1" },
-                                                 :part_three=>{ :part_a => "part_ay",
-                                                                :part_b => "part_be",
-                                                                :test_process_part => part_to_process
-                                                 }}}} }
-
+      let(:part_to_process) { "${name}:${^name}:${^^name}:${^^^name}" }
+      let(:processed_yml) { 'gg1:g1:c1:p1' }
+      let(:yml_read) { {rspec: { rspec: { parent: { name: "p1",
+                                                    child: { name: "c1",
+                                                                grandchild: { name: "g1",
+                                                                                 ggrandchild: { name: "gg1" }}}},
+                                          family_tree: part_to_process }}}}
       let(:target_env) { environment.hadoop_env.to_sym }
       let(:target_yml) { [yml_read[target_env]] }
 
       it 'process yml variables' do
-        expect(environment.yml_expand(yml_read, target_yml)[:rspec][:item_one][:part_three][:test_process_part]).to eq processed_yml
+        expect(environment.yml_expand(yml_read, target_yml)[:rspec][:rspec][:family_tree]).to eq processed_yml
       end
     end
   end

--- a/topics/master/clusters.yml.txt
+++ b/topics/master/clusters.yml.txt
@@ -20,6 +20,31 @@ The clusters.yml file will typically look something like the following:
       :jobTracker: hadoop-stage.mycompany.com:8050
       :oozie_url: http://hadoop-stage.mycompany.com:11000/oozie
 
+To reduce repetition, employ back referencing values previously defined in the file using the ${} operator with or without the ^ specifier.
+The earlier clusters.yml file example could be modified as follows to reduce repetition
+and to assure consistency of definitions.
+
+    :standardSuffixes : &suffixes
+      :namePort: 8020
+      :oozieSuffix: 11000/oozie
+      :jobTrackerPort: 8050
+
+    :templates: &templates
+      :nameNode: hdfs://${^hadoopBaseUrl}/:${namePort)
+      :jobTracker: ${^hadoopBaseUrl}:${jobTrackerPort)
+      :oozie_url: http://${^hadoopBaseUrl}:${oozieSuffix)
+
+    :production:
+      <<suffixes
+      :hadoopBaseUrl: hadoop-prod.mycompany.com
+      <<: *templates
+
+     :staging:
+       <<suffixes
+       :hadoopBaseUrl: hadoop-stage.mycompany.com
+       <<: *templates
+
+
 The section (staging or production) that Hodor uses (e.g. the "target cluster") is configured using:
 
     $ export HADOOP_ENV=production

--- a/topics/master/yaml_processing_extensions.txt
+++ b/topics/master/yaml_processing_extensions.txt
@@ -1,0 +1,77 @@
+YAML Processing Extensions
+---------------------------------------------------------------------------------------------------
+
+Variable back-referencing:
+------------------------------
+
+In order to reduce repetition in .yml property files Hodor has implemented variable back referencing.
+Wrapping a string in ${} indicates it is a back reference to a variable. The ^ qualifier is used to specify which of the
+referenced versions of the property to return if the property is defined at more than one level of the yml definitions.
+
+In the YAML snippet below the property first is defined at four different levels:
+
+:first: o1
+:family:
+  :first: p1
+    :children:
+      :first: c1
+      :second: c2
+      :third: c3
+      :grandchildren:
+        :first: g1
+        :second: g2
+        :third: g3
+        :ggrandchildren:
+          :first: gg1
+          :second: gg2
+          :third: gg3
+          :fourth: gg4
+:first_ggrandparent: ${^^^^^first}
+:first_grandparent: ${^^^^first}
+:first_parent: ${^^^first}
+:first_child: ${^^first}
+:first_grandchild: ${^first}
+:first_ggrandchild: ${first}
+
+The variables using back references would resolve to the following:
+:first_ggrandparent => "first",
+:first_grandparent => "o1",
+:first_parent => "p1",
+:first_child => "c1",
+:first_grandchild => "g1",
+:first_ggrandchild => "gg1"
+
+This is because when a reference is found the application walks back uo to the root of the currently defined tree of properties then
+walks down to the bottom of the tree collecting values for any properties with a matching key.  The values are stored from the
+bottom up so "first" unqualified returns the lowest level property value, ^first returns the second lowest etc.  If there is no
+match for the property at the specified level or there is not property with a matching name then the key is returned.
+The first_ggrandparent is not defined so the key is returned.
+
+
+This functionality in combination with simple yml processing makes it possible to reduce repetition and assure consistency in
+.yml file definitions.  For example, a cluster file could be defined as follows
+
+    :standardSuffixes : &suffixes
+      :namePort: 8020
+      :oozieSuffix: 11000/oozie
+      :jobTrackerPort: 8050
+
+    :templates: &templates
+       :nameNode: hdfs://${^hadoopBaseUrl}/:${namePort)
+       :jobTracker: ${^hadoopBaseUrl}:${jobTrackerPort)
+       :oozie_url: http://${^hadoopBaseUrl}:${oozieSuffix)
+
+    :production:
+      <<suffixes
+      :hadoopBaseUrl: hadoop-prod.mycompany.com
+      <<: *templates
+
+    :staging:
+      <<suffixes
+      :hadoopBaseUrl: hadoop-stage.mycompany.com
+      <<: *templates
+
+To verify property definitions in the clusters.yml file use:
+    $ hodor master:print
+
+

--- a/topics/master/yaml_processing_extensions.txt
+++ b/topics/master/yaml_processing_extensions.txt
@@ -4,9 +4,48 @@ YAML Processing Extensions
 Variable back-referencing:
 ------------------------------
 
-In order to reduce repetition in .yml property files Hodor has implemented variable back referencing.
-Wrapping a string in ${} indicates it is a back reference to a variable. The ^ qualifier is used to specify which of the
-referenced versions of the property to return if the property is defined at more than one level of the yml definitions.
+In order to reduce repetition in YAML property files Hodor has implemented variable expansion and back
+referencing. How does this help? In normal YAML property file processing, there is no way to reuse values
+within the same YAML file. For example, in the below YAML fragment, we are forced to repeat the string
+"hadoop.vpc.acme.com" 4 times:
+
+  :nameNode: hdfs://name01.hadoop.vpc.acme.com:8020
+  :oozie_url: http://name01.hadoop.vpc.acme.com:11000/oozie/
+  :hive_jdbc: jdbc:hive2://name02.hadoop.vpc.acme.com:10000/
+  :hive_host: name02.hadoop.vpc.rgops.com
+
+By default, YAML offers no means of reusing a common string. However, with Hodor's variable expansion and
+back referencing feature, we can rewrite this YAML fragment with less repeatition:
+
+  :hadoopBaseUrl: name01.hadoop.vpc.acme.com
+  :nameNode: hdfs://name01.${hadoopBaseUrl}:8020
+  :oozie_url: http://name01.${hadoopBaseUrl}:11000/oozie/
+  :hive_jdbc: jdbc:hive2://name02.${hadoopBaseUrl}:10000/
+  :hive_host: name02.${hadoopBaseUrl}
+
+Wrapping a string in ${} indicates it is a back reference to a variable. It is a back reference because
+the variable must be defined before it can be subsequently expanded. Attempting to expand a variable that
+is defined later in the YAML file will fail to expand.
+
+Back references can expand values defined at the same level or within a parent, using the '^' qualifier.
+The '^' qualifier instructs Hodor to go up one level in the YAML hierarchy to find a value for the variable
+example. More than one '^' qualifier is allowed, traversing up one more parent for each '^'. An example
+that uses up reference ('^') follows:
+
+production:
+  :mysql_host: gamma-db-host.acme.com
+  :mysql_port: 3306
+  :database:
+    :name: production_data
+    :connection_string:  jdbc:mysql://${^msql_host}:${^mysql_port}/${name}
+
+Note that the connection string has three variable expansions, two that include '^' qualifiers. Both
+mysql_host and mysql_port are defined by the parent of connection_string, so the '^' qualifier causes
+Hodor to look to the parent for values. On the other hand, the ${name} variable is defined at the
+same hierarchical level, and therefore no '^' is required to locate its value.
+
+More precisely, the ^ qualifier is used to specify which of the referenced versions of the property to
+return if the property is defined at more than one level of the yml definitions.
 
 In the YAML snippet below the property first is defined at four different levels:
 

--- a/topics/master/yaml_processing_extensions.txt
+++ b/topics/master/yaml_processing_extensions.txt
@@ -47,44 +47,37 @@ same hierarchical level, and therefore no '^' is required to locate its value.
 More precisely, the ^ qualifier is used to specify which of the referenced versions of the property to
 return if the property is defined at more than one level of the yml definitions.
 
-In the YAML snippet below the property first is defined at four different levels:
+The YAML snippet below provides a more complex example the property name is defined at five different levels:
 
-:first: o1
+:name: o1
 :family:
-  :first: p1
+  :name: p1
     :children:
-      :first: c1
-      :second: c2
-      :third: c3
+      :name: c1
       :grandchildren:
-        :first: g1
-        :second: g2
-        :third: g3
+        :name: g1
         :ggrandchildren:
-          :first: gg1
-          :second: gg2
-          :third: gg3
-          :fourth: gg4
-:first_ggrandparent: ${^^^^^first}
-:first_grandparent: ${^^^^first}
-:first_parent: ${^^^first}
-:first_child: ${^^first}
-:first_grandchild: ${^first}
-:first_ggrandchild: ${first}
+          :name: gg1
+:ggrandparent: ${^^^^^name}
+:grandparent: ${^^^^name}
+:parent: ${^^^name}
+:child: ${^^name}
+:grandchild: ${^name}
+:ggrandchild: ${name}
 
 The variables using back references would resolve to the following:
-:first_ggrandparent => "first",
-:first_grandparent => "o1",
-:first_parent => "p1",
-:first_child => "c1",
-:first_grandchild => "g1",
-:first_ggrandchild => "gg1"
+:ggrandparent => "name",
+:grandparent => "o1",
+:parent => "p1",
+:child => "c1",
+:grandchild => "g1",
+:ggrandchild => "gg1"
 
 This is because when a reference is found the application walks back uo to the root of the currently defined tree of properties then
 walks down to the bottom of the tree collecting values for any properties with a matching key.  The values are stored from the
-bottom up so "first" unqualified returns the lowest level property value, ^first returns the second lowest etc.  If there is no
+bottom up so "name" unqualified returns the lowest level property value, ^name returns the second lowest etc.  If there is no
 match for the property at the specified level or there is not property with a matching name then the key is returned.
-The first_ggrandparent is not defined so the key is returned.
+The ggrandparent is not defined so the key is returned.
 
 
 This functionality in combination with simple yml processing makes it possible to reduce repetition and assure consistency in

--- a/topics/master/yaml_processing_extensions.txt
+++ b/topics/master/yaml_processing_extensions.txt
@@ -44,8 +44,8 @@ mysql_host and mysql_port are defined by the parent of connection_string, so the
 Hodor to look to the parent for values. On the other hand, the ${name} variable is defined at the
 same hierarchical level, and therefore no '^' is required to locate its value.
 
-More precisely, the ^ qualifier is used to specify which of the referenced versions of the property to
-return if the property is defined at more than one level of the yml definitions.
+When a key is specified at multiple levels within a YAML hierarchy, the ^ qualifier can be used to skip
+values defined at lower levels, and return the value of a parent or grandparent instead. Also, note that
 
 The YAML snippet below provides a more complex example the property name is defined at five different levels:
 
@@ -58,26 +58,26 @@ The YAML snippet below provides a more complex example the property name is defi
         :name: g1
         :ggrandchildren:
           :name: gg1
-:ggrandparent: ${^^^^^name}
-:grandparent: ${^^^^name}
-:parent: ${^^^name}
-:child: ${^^name}
-:grandchild: ${^name}
-:ggrandchild: ${name}
+          :sibling: ${name}
+          :parent: ${^name}
+          :grandparent: ${^^name}
+          :ggrandparent: ${^^^name}
+          :gggrandparent: ${^^^^name}
+          :ggggreantparent: ${^^^^^name}
 
 The variables using back references would resolve to the following:
-:ggrandparent => "name",
-:grandparent => "o1",
-:parent => "p1",
-:child => "c1",
-:grandchild => "g1",
-:ggrandchild => "gg1"
 
-This is because when a reference is found the application walks back uo to the root of the currently defined tree of properties then
-walks down to the bottom of the tree collecting values for any properties with a matching key.  The values are stored from the
-bottom up so "name" unqualified returns the lowest level property value, ^name returns the second lowest etc.  If there is no
-match for the property at the specified level or there is not property with a matching name then the key is returned.
-The ggrandparent is not defined so the key is returned.
+   :sibling => "gg1"
+   :parent => "g1",
+   :grandparent => "c1",
+   :ggrandparent => "p1",
+   :gggrandparent => "o1",
+   :ggggrandparent => "name",
+
+Hodor returns the value for name at the level indicated. Zero '^' qualifiers means to return only a sibling value. One '^' qualifier
+means return only a parent value (or sibling of the parent). Two '^' qualifiers means to return only the grandparent value or value
+of grandparent's sibilings etc.  If there is no match for the property at the specified level or there is not property with a
+matching name then the key is returned.
 
 
 This functionality in combination with simple yml processing makes it possible to reduce repetition and assure consistency in

--- a/topics/master/yaml_processing_extensions.txt
+++ b/topics/master/yaml_processing_extensions.txt
@@ -75,9 +75,9 @@ The variables using back references would resolve to the following:
    :ggggrandparent => "name",
 
 Hodor returns the value for name at the level indicated. Zero '^' qualifiers means to return only a sibling value. One '^' qualifier
-means return only a parent value (or sibling of the parent). Two '^' qualifiers means to return only the grandparent value or value
-of grandparent's sibilings etc.  If there is no match for the property at the specified level or there is not property with a
-matching name then the key is returned.
+means to return only a parent value (or more precisely a value of sibling to parent). Two '^' qualifiers means to return only the
+grandparent's value or value of grandparent's sibilings etc.  If there is no match for the property at the specified level or there
+is no property with a matching name then the key name is returned.
 
 
 This functionality in combination with simple yml processing makes it possible to reduce repetition and assure consistency in


### PR DESCRIPTION
Review ✅  Merge ✅ 
@dhallman this is ready to go.
This change adds yaml property back referencing employing the new ${} operator with or without the ^ qualifier. 
For a detailed description of this extension to basic YAML processing and example usage enter 
`hodor master:topic yaml_processing_extensions` 
at the bash command prompt
